### PR TITLE
Support JSP EL in script tags

### DIFF
--- a/src/com/googlecode/jspcompressor/compressor/JspCompressor.java
+++ b/src/com/googlecode/jspcompressor/compressor/JspCompressor.java
@@ -318,9 +318,9 @@ public class JspCompressor implements Compressor {
             }
             
             scriptBlocks.set(i, scriptBlock);
-			// clear jsp blocks collection for the next iteration.
+            // clear jsp blocks collection for the next iteration.
             jspBlocks.clear();  
-			jspELBlocks.clear();
+            jspELBlocks.clear();
         }
 
     }


### PR DESCRIPTION
Added support for using JSP EL within <script> tags. Previously blocks which contained EL expressions would cause errors and not be compressed.
